### PR TITLE
Create randmap|rm command to select a random map

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -64,27 +64,42 @@ class RandomAmongUs(commands.Cog):
         self.bot = bot
         with open(os.path.join('data', 'settings.txt')) as file:
             self.settings = json.load(file)
+        self.maps = ["MIRA HQ", "Polus", "The Skeld"]
 
     @commands.command(name="randsettings", pass_context=True, aliases=["rs"])
     async def randsettings(self, ctx, setting=''):
-        ''' Generate random option for specified setting
-            <setting> - any of the settings which can be modified in-lobby
+        ''' Select random option for specified setting
+            <setting> can be any of the settings which can be modified in-lobby
             Leaving <setting> blank will randomize all settings
 '''
         setting = setting.title()
         options = self.settings.get(setting)
         fields = {}
         if options is None:
-            title = "Randomize: ALL"
+            title = "Randomize Setting: ALL"
             for opt in self.settings:
                 fields.setdefault(opt, random.choice(self.settings[opt]))
         else:
-            title = f"Randomize: {setting}"
+            title = f"Randomize Setting: {setting}"
             fields.setdefault(setting, random.choice(self.settings[setting]))
         embed = discord.Embed(title=title, color=0xff0000)
         for field in fields:
             embed.add_field(name=field, value=fields[field])
         await ctx.send(embed=embed)
+
+    @commands.command(name="randmap", pass_context=True, aliases=["rm"])
+    async def randmap(self, ctx):
+        ''' Select random map
+'''
+        mapname = random.choice(self.maps)
+        embed = discord.Embed(title="Randomize Map", color=0xff0000)
+        embed.add_field(name="Map", value=mapname)
+        thumb_name = f"{''.join(mapname.split()).lower()}.png"
+        thumb_path = os.path.join(
+            'data', thumb_name)
+        thumbnail = discord.File(thumb_path, thumb_name)
+        embed.set_thumbnail(url=f"attachment://{thumb_name}")
+        await ctx.channel.send(file=thumbnail, embed=embed)
 
 class MapInfo(commands.Cog):
     ''' Allow member to explore available information in Among Us


### PR DESCRIPTION
The command `randmap` (can be aliases to `rm`) selects a random Among Us map. The results are sent in an embed with the name of the map and a thumbnail with the logo of the map. The basic image of the map has been left out due to the amount of time it takes to send such a large file and since the size of the image is massive compared to the amount of body text.

Resolve #21 